### PR TITLE
Fix Zero Length Packet bug

### DIFF
--- a/firmware/usbd_bulk_only_transport/src/bulk_only_transport/bulk_only_transport.rs
+++ b/firmware/usbd_bulk_only_transport/src/bulk_only_transport/bulk_only_transport.rs
@@ -444,8 +444,6 @@ impl<B: UsbBus> BulkOnlyTransport<'_, B> {
     }
 
     fn end_data_transfer(&mut self) -> Result<(), Error> {
-        // Get the csw ready to send
-        self.pack_csw();
 
         // We only send a zero length packet if the last write was a full packet AND we are sending
         // less total bytes than the command header asked for
@@ -453,6 +451,8 @@ impl<B: UsbBus> BulkOnlyTransport<'_, B> {
                         self.state == State::SendingDataToHost &&
                         self.command_status_wrapper.data_residue > 0;
 
+        // Get the csw ready to send
+        self.pack_csw();
 
         // send_zlp or flush are called here because we may not get an interrupt in a timley manner
         // if we don't send immediately and


### PR DESCRIPTION
To determine if a Zero-Length Packet needs to be sent, we check if `data_reminder` is greater than zero at the end of a data transfer.  Before this fix, `pack_csw()` resets `data_remainder` to `CommandStatusWrapper::BYTES` before checking it.  This results in thinking that there was still data to be sent and therefore sending an unnecessary ZLP before the command response.  This causes problems with MacOS Read(10) commands.

Fix by checking `data_remainder` before it is overwritten.